### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/nixos/general.modules/modules.d/boot.nix
+++ b/nixos/general.modules/modules.d/boot.nix
@@ -26,7 +26,7 @@
                 # theme = ;                      # GRUB theme, if default is not suitable for you
                 # users = { ... };               # option for hashed password thing
             };
-            systemd-boot = {                    # systemd-boot options, see https://nixos.wiki/wiki/Bootloader for more
+            systemd-boot = {                    # systemd-boot options, see https://wiki.nixos.org/wiki/Bootloader for more
 		configurationLimit = 5;         # limits of generation
                 enable = true;                  # toggle for enabling systemd-boot
                 memtest86 = {                   # options for memtest86 or https://www.memtest86.com/


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️